### PR TITLE
Normalize names before processing to address Windows long-name mangling

### DIFF
--- a/src/copy-directory.lisp
+++ b/src/copy-directory.lisp
@@ -9,11 +9,13 @@
   "root is an absolute directory, and pathname is an absolute pathname, such
   that pathname is inside of root. Remove the common directory components,
   leaving a relative pathname."
-  (assert (uiop:directory-pathname-p root))
-  (assert (uiop:absolute-pathname-p root))
-  (assert (uiop:absolute-pathname-p pathname))
-  (assert (uiop:subpathp pathname root))
-  (uiop:subpathp pathname root))
+  (let ((root (uiop:truename* root))
+        (pathname (uiop:truename* pathname)))
+    (assert (uiop:directory-pathname-p root))
+    (assert (uiop:absolute-pathname-p root))
+    (assert (uiop:absolute-pathname-p pathname))
+    (assert (uiop:subpathp pathname root))
+    (uiop:subpathp pathname root)))
 
 (defun cl-copy (source destination)
   "Copy everything under source to destination. Pure CL function."


### PR DESCRIPTION
Windows will mangle long directory names into an 8.3 format on some systems.   This can confuse copy-directory if presented with mangled and non-mangled names. We should normalize the names before processing them.